### PR TITLE
converting to the travis-ci module and username/password

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,68 +1,71 @@
-var concat = require('concat-stream');
-var https = require('https');
-var url = require('url');
+var Travis = require('travis-ci');
+var prompt = require('prompt');
+prompt.message = '';
+prompt.delimiter = '';
 
-var api = function(token, repo, host, data, cb) {
-  var host = url.parse(host);
-  var options = {
-    'hostname': host.hostname,
-    'path': host.path,
-    'headers': {
-      'Authorization': 'token ' + token,
-    }
-  };
-
-  if (data) {
-    data = JSON.stringify(data);
-    options.headers['Content-Type'] = 'application/json; charset=UTF-8';
-    options.headers['Content-Length'] = data.length;
-    options.method = 'POST';
-  }
-
-  var req = https.request(options, function(res) {
-    res.pipe(concat(cb));
-  });
-
-  if (data) req.write(data);
-
-  req.end();
-
+var getCredentials = function (cb) {
+  prompt.start();
+   prompt.get([{
+        name: 'username',
+        message: 'github username',
+        required: true
+      }, {
+        name: 'password',
+        message: 'github password',
+        hidden: true
+      }], cb);
 };
 
-var lastBuild = function(token, repo, cb) {
-  api(token, repo, 'https://api.travis-ci.org/repos/' + repo + '/builds', null, function(res) {
-    try {
-      cb(JSON.parse(res.toString())[0].id);
-    }
-    catch (e) {
-      cb(res);
-    }
+var travisPing = function(username, password, repo, cb) {
+  var travis = new Travis({
+    version: '2.0.0'
   });
-};
 
-var travisPing = function(token, repo, cb) {
-  lastBuild(token, repo, function(lastBuildId) {
-    api(token, repo, 'https://api.travis-ci.org/requests', { 'build_id': lastBuildId }, function(res) {
-      if (cb) cb(res.toString());
-      });
+  travis.authenticate({
+    username: username,
+    password: password
+  }, function (err, res) {
+    if (err) {
+      return cb(err);
+    }
+    travis.repos.builds({
+      owner_name: repo.split('/')[0],
+      name: repo.split('/')[1]
+    }, function (err, res) {
+      if (err) {
+        return cb(err);
+      }
+      travis.requests({
+        build_id: res.builds[0].id
+      }, cb);
+    });
   });
 };
 
-exports.ping = function(token, repo, cb) {
-  if (!token || !repo) throw "You need to specify your travis-ci token and the repo you would like to rebuild (eg patrickkettner/travis-ping)";
-  travisPing(token, repo, cb);
+exports.ping = function(username, password, repo, cb) {
+  if (!username || !password || !repo) throw "You need to specify your github credentials and the repo you would like to rebuild (eg patrickkettner/travis-ping)";
+
+  travisPing(username, password, repo, cb);
 };
 
 exports.interpret = function(args) {
-  var token = args[2];
-  var repo = args[3];
-  travisPing(token, repo, function(res) {
-   console.log(JSON.parse(res).flash[0]);
-  });
-
-  if (!token || !repo) {
-  console.log('you need to specify a token and the repo you want to ping');
-  process.exit(1);
+  var repo = args[2];
+  if (!repo) {
+    console.warn('you need to specify the repo you want to ping');
+    process.exit(1);
   }
+  getCredentials(function (err, res) {
+    if (err) {
+      console.warn('request for github credentials failed');
+      process.exit(1);
+    }
+    travisPing(res.username, res.password, repo, function(err, res) {
+      if (err) {
+        console.warn(err);
+        process.exit(1);
+      }
+      console.log(res.flash[0]);
+    });
+  });
 };
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/patrickkettner/travis-ping/issues"
   },
   "dependencies": {
-    "concat-stream": "~1.0.0"
+    "travis-ci": "~1.0.1",
+    "prompt": "~0.2.11"
   }
 }


### PR DESCRIPTION
Removes the need to track down the travis token, which is kind of hard to acquire. The travis-ci module does the login via github using username/password (which are prompted for), and provides functions that replace the manual https requests. Here's what the result looks like in use:

![screen shot 2013-08-02 at 4 27 30 pm](https://f.cloud.github.com/assets/295678/904597/7f254eb0-fbcc-11e2-8334-6069e29645f1.png)
