### PR TITLE
Filtering + token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,38 @@ web scraper).
 
 ```javascript
   var travisPing = require('travis-ping');
-  travisPing.ping({username: 'patrickkettner', password: 'mYr33lP4$5w0rd101jk'}, 'patrickkettner/travis-ping', function(travisResponse) {
-    console.log(travisResponse)
-  })
+  travisPing.ping(
+    {username: 'patrickkettner', password: 'mYr33lP4$5w0rd101jk'}, // Credentials
+    'patrickkettner/travis-ping',                                  // Repository
+    {branch: 'master'},                                            // Filter
+    function(travisResponse) {                                     // Callback
+      console.log(travisResponse)
+    }
+  )
 ```
 ### or as a command line tool
 
 ```shell
-  travis-ping patrickkettner/travis-ping
+  travis-ping patrickkettner/travis-ping [options]
 ```
+
+## Credentials
+
+When run from the commandline, you are asked for your username and credentials.
+
+Alternatively you may supply a [GitHub personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
+with `--token [token]` and use the tool without interaction. When using as a module
+set `{github_token: token}` instead of the username and password;
+
+To connect to the Pro API ([travis-ci.com](http://travis-ci.com)), use the `--pro`
+option. As module, add `pro: true` to the credentials;
+
+## Filter
+
+You can filter on a branch using `--branch [branch]` to restart the last build of
+a specific branch. As module, use `{branch: branch}` as filter.
+
+Use `--push` to restart a build for a push event, excluding builds for pull
+requests. The `--pull-request` option will do the oposite. As module, set
+`{eventType: 'push'}` or `{eventType: 'pull_request'}` as filter.
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ web scraper).
 
 ```javascript
   var travisPing = require('travis-ping');
-  travisPing.ping('patrickkettner', 'mYr33lP4$5w0rd101jk', 'patrickkettner/travis-ping', function(travisResponse) {
+  travisPing.ping({username: 'patrickkettner', password: 'mYr33lP4$5w0rd101jk'}, 'patrickkettner/travis-ping', function(travisResponse) {
     console.log(travisResponse)
   })
 ```

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ web scraper).
 When run from the commandline, you are asked for your username and credentials.
 
 Alternatively you may supply a [GitHub personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
-with `--token [token]` and use the tool without interaction. When using as a module
-set `{github_token: token}` instead of the username and password;
+with `--token [token]` or the `GITHUB_TOKEN` environment variable and use the tool
+without interaction. When using as a module set `{github_token: token}` instead of
+the username and password.
 
 To connect to the Pro API ([travis-ci.com](http://travis-ci.com)), use the `--pro`
-option. As module, add `pro: true` to the credentials;
+option. As module, add `pro: true` to the credentials.
 
 ## Filter
 

--- a/bin/travis-ping
+++ b/bin/travis-ping
@@ -1,3 +1,12 @@
 #!/usr/bin/env node
 
-require("../index.js").interpret(process.argv);
+var settings = require('commander');
+
+settings
+  .usage('[repository] [options]')
+  .option('-t, --token [token]', 'GitHub personal access token')
+  .option('--pro', 'Connect to Travis-CI Pro API')
+  .parse(process.argv);
+
+require("../index.js").interpret(settings.args, settings);
+

--- a/bin/travis-ping
+++ b/bin/travis-ping
@@ -6,6 +6,9 @@ settings
   .usage('[repository] [options]')
   .option('-t, --token [token]', 'GitHub personal access token')
   .option('--pro', 'Connect to Travis-CI Pro API')
+  .option('-b, --branch [branch]', 'Use latest build of this branch')
+  .option('-p, --push', 'Use latest build of a push event')
+  .option('--pull-request', 'Use latest build of a pull request event')
   .parse(process.argv);
 
 require("../index.js").interpret(settings.args, settings);

--- a/index.js
+++ b/index.js
@@ -102,8 +102,10 @@ exports.interpret = function(args, settings) {
     });
   };
   
-  if (settings.token) {
-    ping({github_token: settings.token});
+  var token = settings.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  
+  if (token) {
+    ping({github_token: token});
   } else {
     getCredentials(function (err, res) {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,27 @@ var getCredentials = function (cb) {
   }], cb);
 };
 
-var travisPing = function(credentials, repo, cb) {
+var findBuild = function(travis, builds, commits, filter, cb) {
+  var commitIndex = {};
+  commits.forEach(function(commit) {
+    commitIndex[commit.id] = commit;
+  });
+
+  for (var i = 0; i < builds.length; i++) {
+    var build = builds[i];
+    var commit = commitIndex[build.commit_id];
+  
+    if (filter.eventType && build.event_type !== filter.eventType) continue;
+    if (filter.branch && commit.branch !== filter.branch) continue;
+    
+    return cb(null, build);
+  }
+  
+  var type = (filter.eventType ? filter.eventType.replace('_', ' ') + ' ' : '');
+  return cb('no ' + type + 'builds found for this ' + (filter.branch ? 'branch' : 'repo'));
+};
+
+var travisPing = function(credentials, repo, filter, cb) {
   var travis = new Travis({
     version: '2.0.0',
     pro: credentials.pro
@@ -28,25 +48,32 @@ var travisPing = function(credentials, repo, cb) {
     if (err) {
       return cb(err);
     }
-    travis.repos.builds({
-      owner_name: repo.split('/')[0],
-      name: repo.split('/')[1]
-    }, function (err, res) {
+    
+    travis.repos(repo.split('/')[0], repo.split('/')[1]).builds.get(function (err, res) {
       if (err) {
         return cb(err);
       }
       
-      travis.requests({
-        build_id: res.builds[0].id
-      }, cb);
+      findBuild(travis, res.builds, res.commits, filter, function(err, build) {
+        if (err) {
+          return cb(err);
+        }
+        
+        travis.requests.post({
+          build_id: build.id
+        }, function(err, res) {
+          if (!err && !res.result) err = res.flash[0];
+          cb(err, build);
+        });
+      });
     });
   });
 };
 
-exports.ping = function(credentials, repo, cb) {
+exports.ping = function(credentials, repo, filter, cb) {
   if (!credentials || !repo) throw "You need to specify your github credentials and the repo you would like to rebuild (eg patrickkettner/travis-ping)";
 
-  travisPing(credentials, repo, cb);
+  travisPing(credentials, repo, filter, cb);
 };
 
 exports.interpret = function(args, settings) {
@@ -61,12 +88,17 @@ exports.interpret = function(args, settings) {
   var ping = function(credentials) {
     credentials.pro = settings.pro;
     
-    travisPing(credentials, repo, function(err, res) {
+    filter = {};
+    if (settings.branch) filter.branch = settings.branch; 
+    if (settings.push && !settings.pullRequest) filter.eventType = 'push'; 
+    if (settings.pullRequest && !settings.push) filter.eventType = 'pull_request'; 
+    
+    travisPing(credentials, repo, filter, function(err, build) {
       if (err) {
         console.warn(err);
         process.exit(1);
       }
-      console.log(res.flash[0]);
+      console.log('Successfully restarted build #' + build.number);
     });
   };
   

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "commander": "^2.8.1",
     "prompt": "~0.2.11",
-    "travis-ci": "~1.0.1"
+    "travis-ci": "~2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "travis-ping",
   "preferGlobal": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "manually trigger travis builds",
   "main": "index.js",
   "bin": {
@@ -24,7 +24,8 @@
     "url": "https://github.com/patrickkettner/travis-ping/issues"
   },
   "dependencies": {
-    "travis-ci": "~1.0.1",
-    "prompt": "~0.2.11"
+    "commander": "^2.8.1",
+    "prompt": "~0.2.11",
+    "travis-ci": "~1.0.1"
   }
 }


### PR DESCRIPTION
* Added option to connect with GitHub token instead of u/p
* Pass credentials instead of username / password when using as module
* Added option to connect to Travic-CI pro (= travis-ci.com)
* Filter on branch by name
* Filter on event type (push or pull-request)
* Upgrade to travis-ci package v2.x (from v1.x)
* Show build number in output when successfull
* Show proper error when no builds are found

### :warning: BC Break - Major changes :warning:
